### PR TITLE
Convert xml to UTF-8 explicitly to fix wrong encoding

### DIFF
--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -4,6 +4,7 @@ module Savon
 
     def self.present?(http, xml = nil)
       xml ||= http.body
+      xml.encode!('UTF-8', invalid: :replace, replace: '')
       fault_node  = xml.include?("Fault>")
       soap1_fault = xml.match(/faultcode\/?\>/) && xml.match(/faultstring\/?\>/)
       soap2_fault = xml.include?("Code>") && xml.include?("Reason>")


### PR DESCRIPTION
Fix `ArgumentError: invalid byte sequence in UTF-8`
https://app.honeybadger.io/projects/42520/faults/67779407

https://dekeo.atlassian.net/browse/CHARLIE-1622